### PR TITLE
Cache set logos locally on browse scroll

### DIFF
--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -1,11 +1,15 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../core/data/set_logo_cache.dart';
 import '../core/models/card_model.dart';
 import 'theme.dart';
 
 /// Official FAB set logo for browse lists. Falls back to [setName] when the
 /// logo URL is missing or fails to load (mirrors the web Browse Sets page).
+///
+/// Logos are served from [SetLogoCache] (on-device disk + memory) so scrolling
+/// the browse list does not unload/reload them from the CDN.
 class SetLogoTitle extends StatelessWidget {
   const SetLogoTitle({
     super.key,
@@ -18,6 +22,10 @@ class SetLogoTitle extends StatelessWidget {
   final String? logoUrl;
   final double height;
 
+  /// URLs that have painted successfully this process. Recycled list rows
+  /// skip the set-name placeholder so logos do not appear to "unload".
+  static final Set<String> _warmUrls = <String>{};
+
   @override
   Widget build(BuildContext context) {
     final url = logoUrl;
@@ -27,6 +35,8 @@ class SetLogoTitle extends StatelessWidget {
 
     final scheme = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final alreadyWarm = _warmUrls.contains(url);
+    final dpr = MediaQuery.devicePixelRatioOf(context);
 
     final nameFallback = Text(
       setName,
@@ -41,28 +51,39 @@ class SetLogoTitle extends StatelessWidget {
         constraints: BoxConstraints(maxHeight: height + 4, maxWidth: 240),
         child: CachedNetworkImage(
           imageUrl: url,
+          cacheManager: SetLogoCache.instance,
           height: height,
           fit: BoxFit.contain,
           alignment: Alignment.centerLeft,
-          fadeInDuration: const Duration(milliseconds: 150),
-          placeholder: (_, _) => nameFallback,
+          fadeInDuration: Duration.zero,
+          fadeOutDuration: Duration.zero,
+          memCacheHeight: ((height + 4) * dpr).round(),
+          // Quiet placeholder once we've shown this logo before — avoids the
+          // set-name flash when ListView recycles rows.
+          placeholder: (_, _) => alreadyWarm
+              ? SizedBox(height: height + 4)
+              : nameFallback,
           errorWidget: (_, _, _) => nameFallback,
-          imageBuilder: (_, imageProvider) => Container(
-            height: height + 4,
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-            decoration: BoxDecoration(
-              color: isDark
-                  ? Colors.white.withValues(alpha: 0.06)
-                  : scheme.onSurface.withValues(alpha: 0.04),
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Image(
-              image: imageProvider,
-              height: height,
-              fit: BoxFit.contain,
-              alignment: Alignment.centerLeft,
-            ),
-          ),
+          imageBuilder: (_, imageProvider) {
+            _warmUrls.add(url);
+            return Container(
+              height: height + 4,
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              decoration: BoxDecoration(
+                color: isDark
+                    ? Colors.white.withValues(alpha: 0.06)
+                    : scheme.onSurface.withValues(alpha: 0.04),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Image(
+                image: imageProvider,
+                height: height,
+                fit: BoxFit.contain,
+                alignment: Alignment.centerLeft,
+                gaplessPlayback: true,
+              ),
+            );
+          },
         ),
       ),
     );

--- a/mobile/app/lib/core/data/set_logo_cache.dart
+++ b/mobile/app/lib/core/data/set_logo_cache.dart
@@ -1,0 +1,62 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+/// Long-lived on-device cache for official FAB set logos.
+///
+/// Logos change rarely, so they stay on disk for a year. The browse screen
+/// warms this cache as soon as the URL map loads, then precaches into
+/// Flutter's in-memory [ImageCache] so ListView recycling does not re-hit
+/// the CDN or flash placeholders.
+class SetLogoCache {
+  SetLogoCache._();
+
+  static const key = 'setLogoCache';
+
+  static CacheManager? _instance;
+
+  /// Lazily created so unit tests can import this library without initializing
+  /// platform bindings (CacheManager touches path_provider on construct).
+  static CacheManager get instance => _instance ??= CacheManager(
+        Config(
+          key,
+          stalePeriod: const Duration(days: 365),
+          maxNrOfCacheObjects: 250,
+        ),
+      );
+
+  /// Download every logo into the on-device cache. Already-cached URLs are
+  /// cheap no-ops via [CacheManager].
+  static Future<void> warm(Iterable<String> urls) async {
+    final unique = urls.where((u) => u.isNotEmpty).toSet();
+    await Future.wait(
+      unique.map((url) async {
+        try {
+          await instance.getSingleFile(url);
+        } catch (_) {
+          // Individual CDN failures shouldn't block the rest.
+        }
+      }),
+    );
+  }
+
+  /// Decode logos into Flutter's in-memory [ImageCache] so recycled browse
+  /// rows paint immediately from memory instead of re-decoding from disk.
+  static Future<void> precacheIntoMemory(
+    BuildContext context,
+    Iterable<String> urls,
+  ) async {
+    final unique = urls.where((u) => u.isNotEmpty).toSet();
+    for (final url in unique) {
+      if (!context.mounted) return;
+      try {
+        await precacheImage(
+          CachedNetworkImageProvider(url, cacheManager: instance),
+          context,
+        );
+      } catch (_) {
+        // Skip failed URLs; SetLogoTitle will fall back to the set name.
+      }
+    }
+  }
+}

--- a/mobile/app/lib/core/data/set_logos.dart
+++ b/mobile/app/lib/core/data/set_logos.dart
@@ -45,6 +45,9 @@ class SetLogoMap {
     return _byGroupId[groupId.toString()];
   }
 
+  /// All distinct logo CDN URLs (for disk/memory cache warming).
+  Iterable<String> get urls => _byGroupId.values;
+
   bool get isEmpty => _byGroupId.isEmpty;
   int get length => _byGroupId.length;
 }

--- a/mobile/app/lib/core/providers.dart
+++ b/mobile/app/lib/core/providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,6 +9,7 @@ import 'data/card_repository.dart';
 import 'data/catalog_repository.dart';
 import 'data/collection_repository.dart';
 import 'data/lend_repository.dart';
+import 'data/set_logo_cache.dart';
 import 'data/set_logos.dart';
 import 'data/settings_repository.dart';
 import 'data/trade_repository.dart';
@@ -83,7 +86,13 @@ final cardHashIndexProvider = FutureProvider<CardHashIndex>((ref) async {
 });
 
 /// Official FAB set logos (TCGplayer group id → CDN URL), bundled as an asset.
-final setLogoMapProvider = FutureProvider<SetLogoMap>((ref) => loadSetLogoMap());
+/// After load, logos are downloaded into the on-device [SetLogoCache] so the
+/// browse list can scroll without re-fetching from the CDN.
+final setLogoMapProvider = FutureProvider<SetLogoMap>((ref) async {
+  final map = await loadSetLogoMap();
+  unawaited(SetLogoCache.warm(map.urls));
+  return map;
+});
 
 /// Catalog keyed by printing id, for O(1) lookups (used by the scanner to
 /// resolve hash-match ids to cards on every frame).

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import '../../app/app.dart';
 import '../../app/widgets.dart';
 import '../../core/data/card_repository.dart';
+import '../../core/data/set_logo_cache.dart';
 import '../../core/data/set_logos.dart';
 import '../../core/providers.dart';
 import '../card_detail/card_detail_screen.dart';
@@ -103,17 +104,34 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen> {
 }
 
 /// The list of sets to drill into (shown when the global search is empty).
-class _SetList extends ConsumerWidget {
+class _SetList extends ConsumerStatefulWidget {
   const _SetList();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_SetList> createState() => _SetListState();
+}
+
+class _SetListState extends ConsumerState<_SetList> {
+  var _memoryPrecacheStarted = false;
+
+  void _precacheLogosIfNeeded(SetLogoMap logos) {
+    if (_memoryPrecacheStarted || logos.isEmpty) return;
+    _memoryPrecacheStarted = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      SetLogoCache.precacheIntoMemory(context, logos.urls);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // Flesh and Blood has ~100 sets that grow over time, so the browsable set
     // list is derived from whatever the pipeline has loaded rather than a fixed
     // list. Watching the catalog here also preloads it as soon as the app
     // opens, so tapping into a set later is instant.
     final catalog = ref.watch(catalogProvider);
     final logos = ref.watch(setLogoMapProvider).asData?.value ?? SetLogoMap.empty;
+    _precacheLogosIfNeeded(logos);
     return catalog.when(
       loading: () => const Center(child: CircularProgressIndicator.adaptive()),
       error: (e, _) => _ScrollableCenter(
@@ -147,20 +165,53 @@ class _SetList extends ConsumerWidget {
             final set = sets[i];
             final count = counts[set];
             final logoUrl = logos.urlForGroupId(setIds[set]);
-            return ListTile(
-              title: SetLogoTitle(setName: set, logoUrl: logoUrl),
-              subtitle: count == null ? null : Text('$count cards'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                ref.read(searchFiltersProvider.notifier).enterSet(set);
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => SetCardsScreen(setName: set),
-                  ),
-                );
-              },
+            return _SetTile(
+              setName: set,
+              cardCount: count,
+              logoUrl: logoUrl,
             );
           },
+        );
+      },
+    );
+  }
+}
+
+/// One browsable set row. Kept alive so logos stay mounted while scrolling.
+class _SetTile extends ConsumerStatefulWidget {
+  const _SetTile({
+    required this.setName,
+    required this.cardCount,
+    required this.logoUrl,
+  });
+
+  final String setName;
+  final int? cardCount;
+  final String? logoUrl;
+
+  @override
+  ConsumerState<_SetTile> createState() => _SetTileState();
+}
+
+class _SetTileState extends ConsumerState<_SetTile>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ListTile(
+      title: SetLogoTitle(setName: widget.setName, logoUrl: widget.logoUrl),
+      subtitle:
+          widget.cardCount == null ? null : Text('${widget.cardCount} cards'),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        ref.read(searchFiltersProvider.notifier).enterSet(widget.setName);
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => SetCardsScreen(setName: widget.setName),
+          ),
         );
       },
     );

--- a/mobile/app/pubspec.lock
+++ b/mobile/app/pubspec.lock
@@ -303,7 +303,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   supabase_flutter: ^2.15.4
   cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
   intl: ^0.20.3
   flutter_riverpod: ^3.3.2
   fl_chart: ^1.2.0

--- a/mobile/app/test/core/data/set_logos_test.dart
+++ b/mobile/app/test/core/data/set_logos_test.dart
@@ -1,0 +1,47 @@
+import 'package:fabtrades/core/data/set_logo_cache.dart';
+import 'package:fabtrades/core/data/set_logos.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SetLogoMap', () {
+    test('parses nested logos shape and exposes urls', () {
+      const json = '''
+      {
+        "logos": {
+          "2724": { "name": "Crucible of War", "logoUrl": "https://example.com/cru.png" },
+          "2725": { "name": "Arcane Rising", "logoUrl": "https://example.com/arc.png" }
+        }
+      }
+      ''';
+      final map = SetLogoMap.fromJson(json);
+      expect(map.length, 2);
+      expect(map.urlForGroupId(2724), 'https://example.com/cru.png');
+      expect(map.urls.toSet(), {
+        'https://example.com/cru.png',
+        'https://example.com/arc.png',
+      });
+    });
+
+    test('parses flat map shape', () {
+      const json = '''
+      {
+        "2724": "https://example.com/cru.png"
+      }
+      ''';
+      final map = SetLogoMap.fromJson(json);
+      expect(map.urlForGroupId(2724), 'https://example.com/cru.png');
+      expect(map.urls, ['https://example.com/cru.png']);
+    });
+
+    test('returns null for missing group ids', () {
+      expect(SetLogoMap.empty.urlForGroupId(1), isNull);
+      expect(SetLogoMap.empty.urlForGroupId(null), isNull);
+    });
+  });
+
+  group('SetLogoCache', () {
+    test('uses a dedicated long-lived cache key', () {
+      expect(SetLogoCache.key, 'setLogoCache');
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Set logos on the mobile Browse screen were unloading whenever list rows scrolled offscreen, then appearing to reload from the network.

## Changes
- Added a dedicated on-device `SetLogoCache` (`flutter_cache_manager`) that keeps logos for a year
- Warm the disk cache as soon as the logo URL map loads
- Precache logos into Flutter's in-memory image cache when Browse opens
- Point `SetLogoTitle` at the local cache, remove fade-in flash, and skip the set-name placeholder for logos already shown this session
- Keep set list tiles alive while scrolling so logos stay mounted

## Testing
- `flutter analyze` on changed files — clean
- `flutter test test/core/data/set_logos_test.dart test/widgets/app_smoke_test.dart` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71c3-3e98-76fe-aa3f-c78f5e030617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71c3-3e98-76fe-aa3f-c78f5e030617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

