### PR TITLE
Enlarge browse set logos by removing card counts

### DIFF
--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -15,7 +15,7 @@ class SetLogoTitle extends StatelessWidget {
     super.key,
     required this.setName,
     this.logoUrl,
-    this.height = 28,
+    this.height = 40,
   });
 
   final String setName;
@@ -37,6 +37,7 @@ class SetLogoTitle extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final alreadyWarm = _warmUrls.contains(url);
     final dpr = MediaQuery.devicePixelRatioOf(context);
+    final plateHeight = height + 6;
 
     final nameFallback = Text(
       setName,
@@ -48,7 +49,7 @@ class SetLogoTitle extends StatelessWidget {
     return Align(
       alignment: Alignment.centerLeft,
       child: ConstrainedBox(
-        constraints: BoxConstraints(maxHeight: height + 4, maxWidth: 240),
+        constraints: BoxConstraints(maxHeight: plateHeight, maxWidth: 280),
         child: CachedNetworkImage(
           imageUrl: url,
           cacheManager: SetLogoCache.instance,
@@ -57,18 +58,18 @@ class SetLogoTitle extends StatelessWidget {
           alignment: Alignment.centerLeft,
           fadeInDuration: Duration.zero,
           fadeOutDuration: Duration.zero,
-          memCacheHeight: ((height + 4) * dpr).round(),
+          memCacheHeight: (plateHeight * dpr).round(),
           // Quiet placeholder once we've shown this logo before — avoids the
           // set-name flash when ListView recycles rows.
           placeholder: (_, _) => alreadyWarm
-              ? SizedBox(height: height + 4)
+              ? SizedBox(height: plateHeight)
               : nameFallback,
           errorWidget: (_, _, _) => nameFallback,
           imageBuilder: (_, imageProvider) {
             _warmUrls.add(url);
             return Container(
-              height: height + 4,
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              height: plateHeight,
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
               decoration: BoxDecoration(
                 color: isDark
                     ? Colors.white.withValues(alpha: 0.06)

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -141,14 +141,12 @@ class _SetListState extends ConsumerState<_SetList> {
         ),
       ),
       data: (cards) {
-        final counts = <String, int>{};
         // setName → TCGplayer group id (for logo lookup). First seen wins.
         final setIds = <String, int>{};
         for (final c in cards) {
           if (isNonCardProduct(c)) continue;
           final s = c.setName;
           if (s == null) continue;
-          counts[s] = (counts[s] ?? 0) + 1;
           final id = c.setId;
           if (id != null) setIds.putIfAbsent(s, () => id);
         }
@@ -163,11 +161,9 @@ class _SetListState extends ConsumerState<_SetList> {
           separatorBuilder: (_, _) => const Divider(height: 1, indent: 16),
           itemBuilder: (context, i) {
             final set = sets[i];
-            final count = counts[set];
             final logoUrl = logos.urlForGroupId(setIds[set]);
             return _SetTile(
               setName: set,
-              cardCount: count,
               logoUrl: logoUrl,
             );
           },
@@ -181,12 +177,10 @@ class _SetListState extends ConsumerState<_SetList> {
 class _SetTile extends ConsumerStatefulWidget {
   const _SetTile({
     required this.setName,
-    required this.cardCount,
     required this.logoUrl,
   });
 
   final String setName;
-  final int? cardCount;
   final String? logoUrl;
 
   @override
@@ -202,9 +196,8 @@ class _SetTileState extends ConsumerState<_SetTile>
   Widget build(BuildContext context) {
     super.build(context);
     return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       title: SetLogoTitle(setName: widget.setName, logoUrl: widget.logoUrl),
-      subtitle:
-          widget.cardCount == null ? null : Text('${widget.cardCount} cards'),
       trailing: const Icon(Icons.chevron_right),
       onTap: () {
         ref.read(searchFiltersProvider.notifier).enterSet(widget.setName);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On the mobile Browse screen, each set row showed a “N cards” subtitle under the set logo. That text is removed so the logos can use the freed vertical space and read more clearly.

## Changes
- Remove the per-set card total from Browse set rows
- Increase default set logo height from 28 → 40 and max width from 240 → 280
- Add a bit of vertical padding on set rows so the larger logos breathe

## Test plan
- [ ] Open Browse on mobile with an empty search
- [ ] Confirm set rows no longer show “N cards”
- [ ] Confirm set logos are larger and still legible in light and dark mode
- [ ] Confirm tapping a set still opens that set’s cards
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71f3-b1e2-78bb-8a2d-27a0df4287b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71f3-b1e2-78bb-8a2d-27a0df4287b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

