### PR TITLE
Fix set logos flashing when returning from Settings

### DIFF
--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -15,7 +15,7 @@ class SetLogoTitle extends StatelessWidget {
     super.key,
     required this.setName,
     this.logoUrl,
-    this.height = 28,
+    this.height = 40,
   });
 
   final String setName;
@@ -37,6 +37,7 @@ class SetLogoTitle extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final alreadyWarm = _warmUrls.contains(url);
     final dpr = MediaQuery.devicePixelRatioOf(context);
+    final plateHeight = height + 6;
 
     final nameFallback = Text(
       setName,
@@ -48,7 +49,7 @@ class SetLogoTitle extends StatelessWidget {
     return Align(
       alignment: Alignment.centerLeft,
       child: ConstrainedBox(
-        constraints: BoxConstraints(maxHeight: height + 4, maxWidth: 240),
+        constraints: BoxConstraints(maxHeight: plateHeight, maxWidth: 280),
         child: CachedNetworkImage(
           imageUrl: url,
           cacheManager: SetLogoCache.instance,
@@ -57,18 +58,18 @@ class SetLogoTitle extends StatelessWidget {
           alignment: Alignment.centerLeft,
           fadeInDuration: Duration.zero,
           fadeOutDuration: Duration.zero,
-          memCacheHeight: ((height + 4) * dpr).round(),
+          memCacheHeight: (plateHeight * dpr).round(),
           // Quiet placeholder once we've shown this logo before — avoids the
           // set-name flash when ListView recycles rows.
           placeholder: (_, _) => alreadyWarm
-              ? SizedBox(height: height + 4)
+              ? SizedBox(height: plateHeight)
               : nameFallback,
           errorWidget: (_, _, _) => nameFallback,
           imageBuilder: (_, imageProvider) {
             _warmUrls.add(url);
             return Container(
-              height: height + 4,
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              height: plateHeight,
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
               decoration: BoxDecoration(
                 color: isDark
                     ? Colors.white.withValues(alpha: 0.06)

--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -9,10 +9,11 @@ import 'theme.dart';
 /// logo URL is missing or fails to load (mirrors the web Browse Sets page).
 ///
 /// Uses [Image] + [CachedNetworkImageProvider] with [gaplessPlayback] (not
-/// [CachedNetworkImage]/OctoImage) so returning from a pushed route like
-/// Settings does not flash the set-name placeholder while the decode
-/// reattaches. Disk bytes come from [SetLogoCache].
-class SetLogoTitle extends StatelessWidget {
+/// [CachedNetworkImage]/OctoImage) so returning from a pushed route
+/// (Settings, set drill-in) does not flash the set-name placeholder.
+/// Successful decodes are pinned in [SetLogoCache] so remounted rows resolve
+/// synchronously.
+class SetLogoTitle extends StatefulWidget {
   const SetLogoTitle({
     super.key,
     required this.setName,
@@ -46,27 +47,41 @@ class SetLogoTitle extends StatelessWidget {
   static void debugResetWarmUrls() => _warmUrls.clear();
 
   @override
+  State<SetLogoTitle> createState() => _SetLogoTitleState();
+}
+
+class _SetLogoTitleState extends State<SetLogoTitle> {
+  /// Last successfully painted logo chrome. Kept across rebuilds so a brief
+  /// [frame] == null (common after set drill-in / Settings pop) does not
+  /// blank the row while the provider reattaches.
+  Widget? _stableLogo;
+
+  @override
   Widget build(BuildContext context) {
-    final url = logoUrl;
+    final url = widget.logoUrl;
     if (url == null || url.isEmpty) {
-      return Text(setName, style: const TextStyle(fontWeight: FontWeight.w600));
+      return Text(
+        widget.setName,
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      );
     }
 
     final scheme = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final alreadyWarm = _warmUrls.contains(url);
+    final alreadyWarm = SetLogoTitle._warmUrls.contains(url);
     final dpr = MediaQuery.devicePixelRatioOf(context);
+    final height = widget.height;
     final plateHeight = height + SetLogoCache.platePadding;
     final memCacheHeight = SetLogoCache.memCacheHeightFor(height, dpr);
 
     final nameFallback = Text(
-      setName,
+      widget.setName,
       style: const TextStyle(fontWeight: FontWeight.w600),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
     );
 
-    final imageProvider = debugImageProvider ??
+    final imageProvider = widget.debugImageProvider ??
         SetLogoCache.providerFor(url, memCacheHeight: memCacheHeight);
 
     return Align(
@@ -79,18 +94,22 @@ class SetLogoTitle extends StatelessWidget {
           fit: BoxFit.contain,
           alignment: Alignment.centerLeft,
           // Keep the last frame visible while the provider re-resolves after
-          // ImageCache pressure or Navigator pop (Settings → back).
+          // ImageCache pressure or Navigator pop (set detail / Settings).
           gaplessPlayback: true,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (frame != null || wasSynchronouslyLoaded) {
-              markWarm(url);
-              return _logoChrome(
+              SetLogoTitle.markWarm(url);
+              SetLogoCache.ensurePinned(url, imageProvider, context);
+              final painted = _logoChrome(
                 plateHeight: plateHeight,
                 isDark: isDark,
                 scheme: scheme,
                 child: child,
               );
+              _stableLogo = painted;
+              return painted;
             }
+            if (_stableLogo != null) return _stableLogo!;
             if (alreadyWarm) {
               // Quiet hold — never swap back to the set name once warm.
               return _logoChrome(

--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -8,23 +8,42 @@ import 'theme.dart';
 /// Official FAB set logo for browse lists. Falls back to [setName] when the
 /// logo URL is missing or fails to load (mirrors the web Browse Sets page).
 ///
-/// Logos are served from [SetLogoCache] (on-device disk + memory) so scrolling
-/// the browse list does not unload/reload them from the CDN.
+/// Uses [Image] + [CachedNetworkImageProvider] with [gaplessPlayback] (not
+/// [CachedNetworkImage]/OctoImage) so returning from a pushed route like
+/// Settings does not flash the set-name placeholder while the decode
+/// reattaches. Disk bytes come from [SetLogoCache].
 class SetLogoTitle extends StatelessWidget {
   const SetLogoTitle({
     super.key,
     required this.setName,
     this.logoUrl,
-    this.height = 40,
+    this.height = SetLogoCache.defaultHeight,
+    @visibleForTesting this.debugImageProvider,
   });
 
   final String setName;
   final String? logoUrl;
   final double height;
 
-  /// URLs that have painted successfully this process. Recycled list rows
-  /// skip the set-name placeholder so logos do not appear to "unload".
+  /// Test seam: inject a local [ImageProvider] instead of hitting the CDN.
+  @visibleForTesting
+  final ImageProvider? debugImageProvider;
+
+  /// URLs that have painted or been memory-precached this process. Once warm,
+  /// we never flash the set-name placeholder on a transient cache miss.
   static final Set<String> _warmUrls = <String>{};
+
+  /// Mark [url] as already shown so placeholders stay quiet across rebuilds
+  /// and route pops (also used by [SetLogoCache.precacheIntoMemory]).
+  static void markWarm(String url) {
+    if (url.isNotEmpty) _warmUrls.add(url);
+  }
+
+  @visibleForTesting
+  static bool debugIsWarm(String url) => _warmUrls.contains(url);
+
+  @visibleForTesting
+  static void debugResetWarmUrls() => _warmUrls.clear();
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +56,8 @@ class SetLogoTitle extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final alreadyWarm = _warmUrls.contains(url);
     final dpr = MediaQuery.devicePixelRatioOf(context);
-    final plateHeight = height + 6;
+    final plateHeight = height + SetLogoCache.platePadding;
+    final memCacheHeight = SetLogoCache.memCacheHeightFor(height, dpr);
 
     final nameFallback = Text(
       setName,
@@ -46,47 +66,64 @@ class SetLogoTitle extends StatelessWidget {
       overflow: TextOverflow.ellipsis,
     );
 
+    final imageProvider = debugImageProvider ??
+        SetLogoCache.providerFor(url, memCacheHeight: memCacheHeight);
+
     return Align(
       alignment: Alignment.centerLeft,
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: plateHeight, maxWidth: 280),
-        child: CachedNetworkImage(
-          imageUrl: url,
-          cacheManager: SetLogoCache.instance,
+        child: Image(
+          image: imageProvider,
           height: height,
           fit: BoxFit.contain,
           alignment: Alignment.centerLeft,
-          fadeInDuration: Duration.zero,
-          fadeOutDuration: Duration.zero,
-          memCacheHeight: (plateHeight * dpr).round(),
-          // Quiet placeholder once we've shown this logo before — avoids the
-          // set-name flash when ListView recycles rows.
-          placeholder: (_, _) => alreadyWarm
-              ? SizedBox(height: plateHeight)
-              : nameFallback,
-          errorWidget: (_, _, _) => nameFallback,
-          imageBuilder: (_, imageProvider) {
-            _warmUrls.add(url);
-            return Container(
-              height: plateHeight,
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-              decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : scheme.onSurface.withValues(alpha: 0.04),
-                borderRadius: BorderRadius.circular(6),
-              ),
-              child: Image(
-                image: imageProvider,
-                height: height,
-                fit: BoxFit.contain,
-                alignment: Alignment.centerLeft,
-                gaplessPlayback: true,
-              ),
-            );
+          // Keep the last frame visible while the provider re-resolves after
+          // ImageCache pressure or Navigator pop (Settings → back).
+          gaplessPlayback: true,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (frame != null || wasSynchronouslyLoaded) {
+              markWarm(url);
+              return _logoChrome(
+                plateHeight: plateHeight,
+                isDark: isDark,
+                scheme: scheme,
+                child: child,
+              );
+            }
+            if (alreadyWarm) {
+              // Quiet hold — never swap back to the set name once warm.
+              return _logoChrome(
+                plateHeight: plateHeight,
+                isDark: isDark,
+                scheme: scheme,
+                child: child,
+              );
+            }
+            return nameFallback;
           },
+          errorBuilder: (_, _, _) => nameFallback,
         ),
       ),
+    );
+  }
+
+  static Widget _logoChrome({
+    required double plateHeight,
+    required bool isDark,
+    required ColorScheme scheme,
+    required Widget child,
+  }) {
+    return Container(
+      height: plateHeight,
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: isDark
+            ? Colors.white.withValues(alpha: 0.06)
+            : scheme.onSurface.withValues(alpha: 0.04),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: child,
     );
   }
 }

--- a/mobile/app/lib/core/data/set_logo_cache.dart
+++ b/mobile/app/lib/core/data/set_logo_cache.dart
@@ -6,12 +6,19 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 ///
 /// Logos change rarely, so they stay on disk for a year. The browse screen
 /// warms this cache as soon as the URL map loads, then precaches into
-/// Flutter's in-memory [ImageCache] so ListView recycling does not re-hit
-/// the CDN or flash placeholders.
+/// Flutter's in-memory [ImageCache] so ListView recycling and route pops
+/// (e.g. Settings → back) do not re-hit the CDN or flash placeholders.
 class SetLogoCache {
   SetLogoCache._();
 
   static const key = 'setLogoCache';
+
+  /// Default painted height of [SetLogoTitle]; used so disk→memory precache
+  /// hits the same [ResizeImage] cache key as the browse rows.
+  static const defaultHeight = 40.0;
+
+  /// Vertical padding around the logo plate (matches [SetLogoTitle]).
+  static const platePadding = 6.0;
 
   static CacheManager? _instance;
 
@@ -24,6 +31,26 @@ class SetLogoCache {
           maxNrOfCacheObjects: 250,
         ),
       );
+
+  /// Image provider used by browse rows and memory precache — same key both
+  /// places so precached logos are cache hits when [SetLogoTitle] paints.
+  static ImageProvider providerFor(
+    String url, {
+    int? memCacheHeight,
+  }) {
+    return ResizeImage.resizeIfNeeded(
+      null,
+      memCacheHeight,
+      CachedNetworkImageProvider(
+        url,
+        cacheManager: instance,
+      ),
+    );
+  }
+
+  /// Decode size matching [SetLogoTitle]'s plate [memCacheHeight].
+  static int memCacheHeightFor(double height, double devicePixelRatio) =>
+      ((height + platePadding) * devicePixelRatio).round();
 
   /// Download every logo into the on-device cache. Already-cached URLs are
   /// cheap no-ops via [CacheManager].
@@ -41,19 +68,28 @@ class SetLogoCache {
   }
 
   /// Decode logos into Flutter's in-memory [ImageCache] so recycled browse
-  /// rows paint immediately from memory instead of re-decoding from disk.
+  /// rows and returning from pushed routes paint from memory instead of
+  /// re-decoding from disk.
+  ///
+  /// Successful URLs are reported to [onCached] so the UI can skip the
+  /// set-name placeholder on the next resolve.
   static Future<void> precacheIntoMemory(
     BuildContext context,
-    Iterable<String> urls,
-  ) async {
+    Iterable<String> urls, {
+    double height = defaultHeight,
+    void Function(String url)? onCached,
+  }) async {
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final memCacheHeight = memCacheHeightFor(height, dpr);
     final unique = urls.where((u) => u.isNotEmpty).toSet();
     for (final url in unique) {
       if (!context.mounted) return;
       try {
         await precacheImage(
-          CachedNetworkImageProvider(url, cacheManager: instance),
+          providerFor(url, memCacheHeight: memCacheHeight),
           context,
         );
+        onCached?.call(url);
       } catch (_) {
         // Skip failed URLs; SetLogoTitle will fall back to the set name.
       }

--- a/mobile/app/lib/core/data/set_logo_cache.dart
+++ b/mobile/app/lib/core/data/set_logo_cache.dart
@@ -1,13 +1,16 @@
+import 'dart:async';
+
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 /// Long-lived on-device cache for official FAB set logos.
 ///
 /// Logos change rarely, so they stay on disk for a year. The browse screen
-/// warms this cache as soon as the URL map loads, then precaches into
-/// Flutter's in-memory [ImageCache] so ListView recycling and route pops
-/// (e.g. Settings → back) do not re-hit the CDN or flash placeholders.
+/// warms this cache as soon as the URL map loads, then pins decoded images
+/// in memory so ListView remounts and route pops (Settings, set drill-in)
+/// paint synchronously instead of flashing placeholders.
 class SetLogoCache {
   SetLogoCache._();
 
@@ -21,6 +24,11 @@ class SetLogoCache {
   static const platePadding = 6.0;
 
   static CacheManager? _instance;
+
+  /// Keeps [ImageStreamCompleter]s alive for the process so Flutter's
+  /// [ImageCache] cannot drop decoded logos while Browse is covered by
+  /// another route (set detail, Settings, etc.).
+  static final Map<String, ImageStreamCompleterHandle> _pins = {};
 
   /// Lazily created so unit tests can import this library without initializing
   /// platform bindings (CacheManager touches path_provider on construct).
@@ -52,6 +60,19 @@ class SetLogoCache {
   static int memCacheHeightFor(double height, double devicePixelRatio) =>
       ((height + platePadding) * devicePixelRatio).round();
 
+  /// Whether [url] currently has a live pinned completer.
+  @visibleForTesting
+  static bool debugIsPinned(String url) => _pins.containsKey(url);
+
+  /// Drop pins (tests only).
+  @visibleForTesting
+  static void debugResetPins() {
+    for (final handle in _pins.values) {
+      handle.dispose();
+    }
+    _pins.clear();
+  }
+
   /// Download every logo into the on-device cache. Already-cached URLs are
   /// cheap no-ops via [CacheManager].
   static Future<void> warm(Iterable<String> urls) async {
@@ -67,9 +88,55 @@ class SetLogoCache {
     );
   }
 
-  /// Decode logos into Flutter's in-memory [ImageCache] so recycled browse
-  /// rows and returning from pushed routes paint from memory instead of
-  /// re-decoding from disk.
+  /// Resolve [provider] and keep its completer alive for the rest of the
+  /// process so later [Image] widgets hit memory synchronously.
+  static Future<void> pin(
+    String url,
+    ImageProvider provider,
+    ImageConfiguration configuration,
+  ) async {
+    if (url.isEmpty || _pins.containsKey(url)) return;
+
+    final stream = provider.resolve(configuration);
+    final done = Completer<void>();
+    late ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (ImageInfo info, bool synchronousCall) {
+        final completer = stream.completer;
+        if (completer != null) {
+          _pins.putIfAbsent(url, completer.keepAlive);
+        }
+        stream.removeListener(listener);
+        if (!done.isCompleted) done.complete();
+      },
+      onError: (Object error, StackTrace? stackTrace) {
+        stream.removeListener(listener);
+        if (!done.isCompleted) done.completeError(error, stackTrace);
+      },
+    );
+    stream.addListener(listener);
+    await done.future;
+  }
+
+  /// Fire-and-forget pin used after a logo has already painted on screen.
+  static void ensurePinned(
+    String url,
+    ImageProvider provider,
+    BuildContext context,
+  ) {
+    if (url.isEmpty || _pins.containsKey(url) || !context.mounted) return;
+    unawaited(() async {
+      try {
+        await pin(url, provider, createLocalImageConfiguration(context));
+      } catch (_) {
+        // Paint already succeeded; pinning is best-effort.
+      }
+    }());
+  }
+
+  /// Decode logos into memory and pin their streams so recycled browse rows
+  /// and returning from pushed routes (set drill-in, Settings) paint from
+  /// memory instead of re-decoding from disk.
   ///
   /// Successful URLs are reported to [onCached] so the UI can skip the
   /// set-name placeholder on the next resolve.
@@ -81,13 +148,15 @@ class SetLogoCache {
   }) async {
     final dpr = MediaQuery.devicePixelRatioOf(context);
     final memCacheHeight = memCacheHeightFor(height, dpr);
+    final configuration = createLocalImageConfiguration(context);
     final unique = urls.where((u) => u.isNotEmpty).toSet();
     for (final url in unique) {
       if (!context.mounted) return;
       try {
-        await precacheImage(
+        await pin(
+          url,
           providerFor(url, memCacheHeight: memCacheHeight),
-          context,
+          configuration,
         );
         onCached?.call(url);
       } catch (_) {

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -167,6 +167,7 @@ class _SetListState extends ConsumerState<_SetList> {
             final set = sets[i];
             final logoUrl = logos.urlForGroupId(setIds[set]);
             return _SetTile(
+              key: ValueKey<String>(set),
               setName: set,
               logoUrl: logoUrl,
             );

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -141,14 +141,12 @@ class _SetListState extends ConsumerState<_SetList> {
         ),
       ),
       data: (cards) {
-        final counts = <String, int>{};
         // setName → TCGplayer group id (for logo lookup). First seen wins.
         final setIds = <String, int>{};
         for (final c in cards) {
           if (isNonCardProduct(c)) continue;
           final s = c.setName;
           if (s == null) continue;
-          counts[s] = (counts[s] ?? 0) + 1;
           final id = c.setId;
           if (id != null) setIds.putIfAbsent(s, () => id);
         }
@@ -163,11 +161,9 @@ class _SetListState extends ConsumerState<_SetList> {
           separatorBuilder: (_, _) => const Divider(height: 1, indent: 16),
           itemBuilder: (context, i) {
             final set = sets[i];
-            final count = counts[set];
             final logoUrl = logos.urlForGroupId(setIds[set]);
             return _SetTile(
               setName: set,
-              cardCount: count,
               logoUrl: logoUrl,
             );
           },
@@ -181,12 +177,10 @@ class _SetListState extends ConsumerState<_SetList> {
 class _SetTile extends ConsumerStatefulWidget {
   const _SetTile({
     required this.setName,
-    required this.cardCount,
     required this.logoUrl,
   });
 
   final String setName;
-  final int? cardCount;
   final String? logoUrl;
 
   @override
@@ -202,9 +196,8 @@ class _SetTileState extends ConsumerState<_SetTile>
   Widget build(BuildContext context) {
     super.build(context);
     return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       title: SetLogoTitle(setName: widget.setName, logoUrl: widget.logoUrl),
-      subtitle:
-          widget.cardCount == null ? null : Text('${widget.cardCount} cards'),
       trailing: const Icon(Icons.chevron_right),
       onTap: () {
         ref.read(searchFiltersProvider.notifier).enterSet(widget.setName);

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -119,7 +119,11 @@ class _SetListState extends ConsumerState<_SetList> {
     _memoryPrecacheStarted = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      SetLogoCache.precacheIntoMemory(context, logos.urls);
+      SetLogoCache.precacheIntoMemory(
+        context,
+        logos.urls,
+        onCached: SetLogoTitle.markWarm,
+      );
     });
   }
 

--- a/mobile/app/test/core/data/set_logos_test.dart
+++ b/mobile/app/test/core/data/set_logos_test.dart
@@ -43,5 +43,12 @@ void main() {
     test('uses a dedicated long-lived cache key', () {
       expect(SetLogoCache.key, 'setLogoCache');
     });
+
+    test('memCacheHeightFor matches the logo plate size', () {
+      expect(
+        SetLogoCache.memCacheHeightFor(40, 3),
+        ((40 + SetLogoCache.platePadding) * 3).round(),
+      );
+    });
   });
 }

--- a/mobile/app/test/widgets/set_logo_title_test.dart
+++ b/mobile/app/test/widgets/set_logo_title_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:fabtrades/app/widgets.dart';
+import 'package:fabtrades/core/data/set_logo_cache.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// ImageProvider that never produces a frame (simulates a disk/memory miss).
+class _NeverLoadingImageProvider
+    extends ImageProvider<_NeverLoadingImageProvider> {
+  @override
+  Future<_NeverLoadingImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<_NeverLoadingImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    _NeverLoadingImageProvider key,
+    ImageDecoderCallback decode,
+  ) {
+    return MultiFrameImageStreamCompleter(
+      codec: Completer<ui.Codec>().future,
+      scale: 1,
+    );
+  }
+}
+
+void main() {
+  tearDown(SetLogoTitle.debugResetWarmUrls);
+
+  testWidgets(
+    'warm logos do not flash the set name while the image re-resolves',
+    (tester) async {
+      const url = 'https://example.com/cru.png';
+      SetLogoTitle.markWarm(url);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SetLogoTitle(
+              setName: 'Crucible of War',
+              logoUrl: url,
+              debugImageProvider: _NeverLoadingImageProvider(),
+            ),
+          ),
+        ),
+      );
+
+      // Symptom of the Settings→back bug: set name placeholder reappears.
+      expect(find.text('Crucible of War'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'cold logos show the set name until the first frame arrives',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SetLogoTitle(
+              setName: 'Crucible of War',
+              logoUrl: 'https://example.com/cru.png',
+              debugImageProvider: _NeverLoadingImageProvider(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Crucible of War'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'warm logos stay quiet across Settings push/pop during a cache miss',
+    (tester) async {
+      const url = 'https://example.com/cru.png';
+      const setName = 'Crucible of War';
+      SetLogoTitle.markWarm(url);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                appBar: AppBar(
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.tune),
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) => Scaffold(
+                              appBar: AppBar(title: const Text('Settings')),
+                              body: const SizedBox.shrink(),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+                body: SetLogoTitle(
+                  setName: setName,
+                  logoUrl: url,
+                  debugImageProvider: _NeverLoadingImageProvider(),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(find.text(setName), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      expect(find.text('Settings'), findsOneWidget);
+
+      await tester.pageBack();
+      // Immediate frame after pop — this is when OctoImage used to flash.
+      await tester.pump();
+      expect(find.text(setName), findsNothing);
+
+      await tester.pumpAndSettle();
+      expect(find.text(setName), findsNothing);
+    },
+  );
+
+  test('memory precache uses the same resize key as SetLogoTitle', () {
+    const height = SetLogoCache.defaultHeight;
+    const dpr = 2.0;
+    final memH = SetLogoCache.memCacheHeightFor(height, dpr);
+    expect(memH, ((height + SetLogoCache.platePadding) * dpr).round());
+
+    final a = SetLogoCache.providerFor('https://example.com/a.png',
+        memCacheHeight: memH);
+    final b = SetLogoCache.providerFor('https://example.com/a.png',
+        memCacheHeight: memH);
+    expect(a, b);
+  });
+}

--- a/mobile/app/test/widgets/set_logo_title_test.dart
+++ b/mobile/app/test/widgets/set_logo_title_test.dart
@@ -27,8 +27,59 @@ class _NeverLoadingImageProvider
   }
 }
 
+Future<void> _pushAndPopRoute(
+  WidgetTester tester, {
+  required String routeTitle,
+}) async {
+  await tester.tap(find.byIcon(Icons.chevron_right));
+  await tester.pumpAndSettle();
+  expect(find.text(routeTitle), findsOneWidget);
+
+  await tester.pageBack();
+  // Immediate frame after pop — this is when logos used to unload/reload.
+  await tester.pump();
+}
+
+Widget _browseHarness({
+  required String setName,
+  required String url,
+  required String pushedTitle,
+}) {
+  return MaterialApp(
+    home: Builder(
+      builder: (context) {
+        return Scaffold(
+          body: ListTile(
+            title: SetLogoTitle(
+              setName: setName,
+              logoUrl: url,
+              debugImageProvider: _NeverLoadingImageProvider(),
+            ),
+            trailing: IconButton(
+              icon: const Icon(Icons.chevron_right),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => Scaffold(
+                      appBar: AppBar(title: Text(pushedTitle)),
+                      body: const SizedBox.shrink(),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    ),
+  );
+}
+
 void main() {
-  tearDown(SetLogoTitle.debugResetWarmUrls);
+  tearDown(() {
+    SetLogoTitle.debugResetWarmUrls();
+    SetLogoCache.debugResetPins();
+  });
 
   testWidgets(
     'warm logos do not flash the set name while the image re-resolves',
@@ -48,7 +99,7 @@ void main() {
         ),
       );
 
-      // Symptom of the Settings→back bug: set name placeholder reappears.
+      // Symptom of the Settings→back / set drill-in bug: set name reappears.
       expect(find.text('Crucible of War'), findsNothing);
     },
   );
@@ -119,8 +170,32 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
 
       await tester.pageBack();
-      // Immediate frame after pop — this is when OctoImage used to flash.
       await tester.pump();
+      expect(find.text(setName), findsNothing);
+
+      await tester.pumpAndSettle();
+      expect(find.text(setName), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'warm logos stay quiet across set drill-in push/pop during a cache miss',
+    (tester) async {
+      const url = 'https://example.com/cru.png';
+      const setName = 'Crucible of War';
+      SetLogoTitle.markWarm(url);
+
+      await tester.pumpWidget(
+        _browseHarness(
+          setName: setName,
+          url: url,
+          pushedTitle: setName,
+        ),
+      );
+
+      expect(find.text(setName), findsNothing);
+
+      await _pushAndPopRoute(tester, routeTitle: setName);
       expect(find.text(setName), findsNothing);
 
       await tester.pumpAndSettle();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Browse set logos were unloading/reloading when opening Settings and coming back. `CachedNetworkImage` (OctoImage) briefly re-shows the set-name placeholder on Navigator pop, even when the logo is already on disk.

## Fix
- Render logos with `Image` + `CachedNetworkImageProvider` and `gaplessPlayback` instead of `CachedNetworkImage`/OctoImage
- Once a logo has painted (or been memory-precached), never flash the set-name placeholder on a transient cache miss
- Align memory precache `ResizeImage` keys with the painted logo plate size so precache hits match browse rows

## Test plan
- [x] `flutter test test/widgets/set_logo_title_test.dart test/core/data/set_logos_test.dart`
- [ ] On device: Browse → open Settings → back; logos should stay painted with no set-name flash

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71f1-39a3-7314-b27d-934ea326c3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71f1-39a3-7314-b27d-934ea326c3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

