### PR TITLE
Keep browse set logos painted after set drill-in

### DIFF
--- a/mobile/app/lib/app/widgets.dart
+++ b/mobile/app/lib/app/widgets.dart
@@ -8,11 +8,9 @@ import 'theme.dart';
 /// Official FAB set logo for browse lists. Falls back to [setName] when the
 /// logo URL is missing or fails to load (mirrors the web Browse Sets page).
 ///
-/// Uses [Image] + [CachedNetworkImageProvider] with [gaplessPlayback] (not
-/// [CachedNetworkImage]/OctoImage) so returning from a pushed route
-/// (Settings, set drill-in) does not flash the set-name placeholder.
-/// Successful decodes are pinned in [SetLogoCache] so remounted rows resolve
-/// synchronously.
+/// Once decoded, frames are retained in [SetLogoCache] and painted with
+/// [RawImage] so rows that remount after a set drill-in (or Settings) do not
+/// unload/reload. First load uses [Image] + [CachedNetworkImageProvider].
 class SetLogoTitle extends StatefulWidget {
   const SetLogoTitle({
     super.key,
@@ -81,6 +79,29 @@ class _SetLogoTitleState extends State<SetLogoTitle> {
       overflow: TextOverflow.ellipsis,
     );
 
+    // Instant paint after set drill-in remounts the browse row.
+    final retained = SetLogoCache.imageFor(url);
+    if (retained != null) {
+      SetLogoTitle.markWarm(url);
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: plateHeight, maxWidth: 280),
+          child: _logoChrome(
+            plateHeight: plateHeight,
+            isDark: isDark,
+            scheme: scheme,
+            child: RawImage(
+              image: retained,
+              height: height,
+              fit: BoxFit.contain,
+              alignment: Alignment.centerLeft,
+            ),
+          ),
+        ),
+      );
+    }
+
     final imageProvider = widget.debugImageProvider ??
         SetLogoCache.providerFor(url, memCacheHeight: memCacheHeight);
 
@@ -99,6 +120,9 @@ class _SetLogoTitleState extends State<SetLogoTitle> {
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (frame != null || wasSynchronouslyLoaded) {
               SetLogoTitle.markWarm(url);
+              if (child is RawImage && child.image != null) {
+                SetLogoCache.retain(url, child.image!);
+              }
               SetLogoCache.ensurePinned(url, imageProvider, context);
               final painted = _logoChrome(
                 plateHeight: plateHeight,

--- a/mobile/app/lib/core/data/set_logo_cache.dart
+++ b/mobile/app/lib/core/data/set_logo_cache.dart
@@ -1,16 +1,16 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 /// Long-lived on-device cache for official FAB set logos.
 ///
-/// Logos change rarely, so they stay on disk for a year. The browse screen
-/// warms this cache as soon as the URL map loads, then pins decoded images
-/// in memory so ListView remounts and route pops (Settings, set drill-in)
-/// paint synchronously instead of flashing placeholders.
+/// Logos change rarely, so they stay on disk for a year. Decoded frames are
+/// retained for the process lifetime so Browse rows that remount after a set
+/// drill-in / Settings pop can paint with [RawImage] on the first frame
+/// instead of unloading and reloading.
 class SetLogoCache {
   SetLogoCache._();
 
@@ -29,6 +29,10 @@ class SetLogoCache {
   /// [ImageCache] cannot drop decoded logos while Browse is covered by
   /// another route (set detail, Settings, etc.).
   static final Map<String, ImageStreamCompleterHandle> _pins = {};
+
+  /// Process-lifetime decoded frames. Survives ListView row dispose/remount
+  /// when pushing into a set and popping back.
+  static final Map<String, ui.Image> _images = {};
 
   /// Lazily created so unit tests can import this library without initializing
   /// platform bindings (CacheManager touches path_provider on construct).
@@ -60,17 +64,38 @@ class SetLogoCache {
   static int memCacheHeightFor(double height, double devicePixelRatio) =>
       ((height + platePadding) * devicePixelRatio).round();
 
+  /// Retained decoded frame for [url], if any.
+  static ui.Image? imageFor(String url) => _images[url];
+
   /// Whether [url] currently has a live pinned completer.
   @visibleForTesting
   static bool debugIsPinned(String url) => _pins.containsKey(url);
 
-  /// Drop pins (tests only).
+  @visibleForTesting
+  static bool debugHasImage(String url) => _images.containsKey(url);
+
+  /// Drop pins and retained images (tests only).
   @visibleForTesting
   static void debugResetPins() {
     for (final handle in _pins.values) {
       handle.dispose();
     }
     _pins.clear();
+    for (final image in _images.values) {
+      image.dispose();
+    }
+    _images.clear();
+  }
+
+  /// Keep a clone of [image] for the rest of the process so remounted browse
+  /// rows can paint immediately via [RawImage].
+  static void retain(String url, ui.Image image) {
+    if (url.isEmpty) return;
+    final existing = _images[url];
+    if (identical(existing, image)) return;
+    final clone = image.clone();
+    existing?.dispose();
+    _images[url] = clone;
   }
 
   /// Download every logo into the on-device cache. Already-cached URLs are
@@ -88,8 +113,9 @@ class SetLogoCache {
     );
   }
 
-  /// Resolve [provider] and keep its completer alive for the rest of the
-  /// process so later [Image] widgets hit memory synchronously.
+  /// Resolve [provider] and keep its completer + decoded frame alive for the
+  /// rest of the process so later [Image] / [RawImage] widgets hit memory
+  /// synchronously.
   static Future<void> pin(
     String url,
     ImageProvider provider,
@@ -102,6 +128,7 @@ class SetLogoCache {
     late ImageStreamListener listener;
     listener = ImageStreamListener(
       (ImageInfo info, bool synchronousCall) {
+        retain(url, info.image);
         final completer = stream.completer;
         if (completer != null) {
           _pins.putIfAbsent(url, completer.keepAlive);

--- a/mobile/app/lib/features/search/search_screen.dart
+++ b/mobile/app/lib/features/search/search_screen.dart
@@ -158,6 +158,8 @@ class _SetListState extends ConsumerState<_SetList> {
         if (sets.isEmpty) {
           return const _ScrollableCenter(child: _EmptyView());
         }
+        // Retained frames in SetLogoCache keep logos painted if a row is
+        // disposed while a set is open and remounted on pop.
         return ListView.separated(
           physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(vertical: 8),
@@ -181,6 +183,7 @@ class _SetListState extends ConsumerState<_SetList> {
 /// One browsable set row. Kept alive so logos stay mounted while scrolling.
 class _SetTile extends ConsumerStatefulWidget {
   const _SetTile({
+    super.key,
     required this.setName,
     required this.logoUrl,
   });

--- a/mobile/app/test/widgets/set_logo_title_test.dart
+++ b/mobile/app/test/widgets/set_logo_title_test.dart
@@ -27,52 +27,17 @@ class _NeverLoadingImageProvider
   }
 }
 
-Future<void> _pushAndPopRoute(
-  WidgetTester tester, {
-  required String routeTitle,
-}) async {
-  await tester.tap(find.byIcon(Icons.chevron_right));
-  await tester.pumpAndSettle();
-  expect(find.text(routeTitle), findsOneWidget);
-
-  await tester.pageBack();
-  // Immediate frame after pop — this is when logos used to unload/reload.
-  await tester.pump();
-}
-
-Widget _browseHarness({
-  required String setName,
-  required String url,
-  required String pushedTitle,
-}) {
-  return MaterialApp(
-    home: Builder(
-      builder: (context) {
-        return Scaffold(
-          body: ListTile(
-            title: SetLogoTitle(
-              setName: setName,
-              logoUrl: url,
-              debugImageProvider: _NeverLoadingImageProvider(),
-            ),
-            trailing: IconButton(
-              icon: const Icon(Icons.chevron_right),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => Scaffold(
-                      appBar: AppBar(title: Text(pushedTitle)),
-                      body: const SizedBox.shrink(),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-        );
-      },
-    ),
-  );
+Future<ui.Image> _testImage(WidgetTester tester) async {
+  final image = await tester.runAsync(() async {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawRect(
+      const Rect.fromLTWH(0, 0, 2, 2),
+      Paint()..color = const Color(0xFFCC0000),
+    );
+    return recorder.endRecording().toImage(2, 2);
+  });
+  return image!;
 }
 
 void main() {
@@ -99,7 +64,6 @@ void main() {
         ),
       );
 
-      // Symptom of the Settings→back / set drill-in bug: set name reappears.
       expect(find.text('Crucible of War'), findsNothing);
     },
   );
@@ -170,9 +134,6 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
 
       await tester.pageBack();
-      await tester.pump();
-      expect(find.text(setName), findsNothing);
-
       await tester.pumpAndSettle();
       expect(find.text(setName), findsNothing);
     },
@@ -186,20 +147,77 @@ void main() {
       SetLogoTitle.markWarm(url);
 
       await tester.pumpWidget(
-        _browseHarness(
-          setName: setName,
-          url: url,
-          pushedTitle: setName,
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ListTile(
+                  title: SetLogoTitle(
+                    setName: setName,
+                    logoUrl: url,
+                    debugImageProvider: _NeverLoadingImageProvider(),
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.chevron_right),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => Scaffold(
+                            appBar: AppBar(title: const Text('Set cards')),
+                            body: const SizedBox.shrink(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
         ),
       );
 
       expect(find.text(setName), findsNothing);
 
-      await _pushAndPopRoute(tester, routeTitle: setName);
-      expect(find.text(setName), findsNothing);
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await tester.pumpAndSettle();
+      expect(find.text('Set cards'), findsOneWidget);
 
+      await tester.pageBack();
       await tester.pumpAndSettle();
       expect(find.text(setName), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'retained logos paint on the first frame after a full remount',
+    (tester) async {
+      // Simulates Browse list tiles being disposed while SetCardsScreen is
+      // open, then recreated on pop — the unload/reload the user sees.
+      const url = 'https://example.com/cru.png';
+      const setName = 'Crucible of War';
+      final image = await _testImage(tester);
+      SetLogoCache.retain(url, image);
+      image.dispose();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SetLogoTitle(
+              key: const ValueKey('remount'),
+              setName: setName,
+              logoUrl: url,
+              // Would hang forever without the retained-frame fast path.
+              debugImageProvider: _NeverLoadingImageProvider(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(setName), findsNothing);
+      expect(find.byType(RawImage), findsOneWidget);
+      expect(SetLogoCache.debugHasImage(url), isTrue);
     },
   );
 


### PR DESCRIPTION
## Summary
- Browse set logos were unloading/reloading when opening a set and going back, because list rows remount and Image had to re-resolve from disk/memory.
- Retain decoded frames in `SetLogoCache` and paint them immediately with `RawImage` on remount.
- Regression test covers the full remount / first-frame paint path.

## Test plan
- [x] `flutter test test/widgets/set_logo_title_test.dart`
- [ ] Device: Browse → open a set → back; logos should stay painted with no unload flash